### PR TITLE
compression logic : improve compression levels and output sizing

### DIFF
--- a/src/services/pdf.service.js
+++ b/src/services/pdf.service.js
@@ -129,32 +129,84 @@ export const imageToPdf = async (files) => {
   return new Blob([pdfBytes], { type: "application/pdf" });
 };
 
-export const compressWithQuality = async (file, quality = 0.5) => {
+export const compressWithQuality = async (file, quality = 0.6) => {
   const arrayBuffer = await file.arrayBuffer();
 
-  // Some PDFs are technically readable but still carry permission flags.
-  const pdfDoc = await PDFDocument.load(arrayBuffer, {
-    ignoreEncryption: true,
-    // This keeps very large files from freezing the browser as easily.
-    capNumbers: true,
-  });
+  const sourcePdf = await pdfjsLib.getDocument({
+    data: arrayBuffer,
+  }).promise;
 
-  const compressedDoc = await PDFDocument.create();
-  const copiedPages = await compressedDoc.copyPages(
-    pdfDoc,
-    pdfDoc.getPageIndices(),
-  );
-  copiedPages.forEach((page) => compressedDoc.addPage(page));
+  const outputPdf = await PDFDocument.create();
 
-  // Object streams usually save a noticeable amount of space on bigger PDFs.
-  const compressedBytes = await compressedDoc.save({
+  let scale;
+  let jpegQuality;
+
+  if (quality >= 0.85) {
+    // HIGH QUALITY
+    // Better compression while keeping clarity
+    scale = 0.92;
+    jpegQuality = 0.72;
+  } else if (quality >= 0.55) {
+    // BALANCED
+    scale = 0.95;
+    jpegQuality = 0.58;
+  } else {
+    // EXTREME
+    scale = 0.75;
+    jpegQuality = 0.38;
+  }
+
+  for (let pageNumber = 1; pageNumber <= sourcePdf.numPages; pageNumber++) {
+    const page = await sourcePdf.getPage(pageNumber);
+
+    const viewport = page.getViewport({ scale });
+
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+
+    canvas.width = Math.floor(viewport.width);
+    canvas.height = Math.floor(viewport.height);
+
+    await page.render({
+      canvasContext: context,
+      viewport,
+    }).promise;
+
+    const imageBlob = await new Promise((resolve) => {
+      canvas.toBlob(resolve, "image/jpeg", jpegQuality);
+    });
+
+    const imageBytes = await imageBlob.arrayBuffer();
+
+    const jpgImage = await outputPdf.embedJpg(imageBytes);
+
+    const pdfPage = outputPdf.addPage([
+      viewport.width,
+      viewport.height,
+    ]);
+
+    pdfPage.drawImage(jpgImage, {
+      x: 0,
+      y: 0,
+      width: viewport.width,
+      height: viewport.height,
+    });
+
+    canvas.width = 0;
+    canvas.height = 0;
+  }
+
+  const pdfBytes = await outputPdf.save({
     useObjectStreams: true,
     addDefaultPage: false,
     updateFieldAppearances: false,
   });
 
-  return new Blob([compressedBytes], { type: "application/pdf" });
+  return new Blob([pdfBytes], {
+    type: "application/pdf",
+  });
 };
+
 
 export const rotatePdf = async (file, rotationAngle) => {
   const arrayBuffer = await file.arrayBuffer();


### PR DESCRIPTION
## Summary

Closes #1

This PR improves the PDF compression tool by making all three compression levels more meaningful, consistent, and user-friendly.

Previously, some compression modes could generate outputs close to or larger than the original file size depending on the PDF. This update improves the compression engine so each tier now behaves as expected.

---

## What Changed

### Compression Logic (`pdf.service.js`)

- Reworked `compressWithQuality()` logic
- Improved differentiation between all 3 modes
- Retained strong Extreme compression

### Compression Levels

- **High Quality** → light compression with preserved clarity
- **Balanced** → moderate compression with noticeable reduction
- **Extreme** → aggressive compression for maximum size savings


## Screenshots

## Before this update:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/902fc223-2f70-4fcc-84ba-1e785f4e39ac" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b7c6e3a4-ee31-4489-a323-1473a822dd12" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/57bef2f2-3b56-4926-802a-5817165adf94" />

## After this update:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0f70ce26-56f7-4f30-b167-77e3366d36c4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/11eafa78-bc97-4cd3-b8c8-2cb9f43f8edf" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0b2cd064-bf89-4b23-9605-12ef4add0806" />







## Observed expected behavior:

- High Quality = minor reduction
- Balanced = medium reduction
- Extreme = maximum reduction



## Checklist

- [x] `npm run dev` runs successfully
- [x] Compression tested locally
- [x] No backend/server uploads introduced
- [x] Focused PR for assigned issue

