### PR TITLE
feat: added preview before download for watermark tool

### DIFF
--- a/src/pages/Watermark/Watermark.jsx
+++ b/src/pages/Watermark/Watermark.jsx
@@ -13,41 +13,57 @@ export function Watermark() {
   const [watermarkText, setWatermarkText] = useState("CONFIDENTIAL");
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
 
-  const { isPremium, hasReachedGlobalLimit, incrementUsage, isWalletConnected } = useSubscription();
+  const {
+    isPremium,
+    hasReachedGlobalLimit,
+    incrementUsage,
+    isWalletConnected,
+  } = useSubscription();
 
-  const fileTooLarge = !isPremium && file && file.size > mbToBytes(FREE_LIMITS.watermark.maxFileSizeMb);
-  const isLocked     = hasReachedGlobalLimit || fileTooLarge;
-  const lockReason   = hasReachedGlobalLimit ? "global" : "size";
-  const lockLabel    = fileTooLarge ? `${FREE_LIMITS.watermark.maxFileSizeMb} MB` : undefined;
+  const fileTooLarge =
+    !isPremium &&
+    file &&
+    file.size > mbToBytes(FREE_LIMITS.watermark.maxFileSizeMb);
+
+  const isLocked = hasReachedGlobalLimit || fileTooLarge;
+  const lockReason = hasReachedGlobalLimit ? "global" : "size";
+  const lockLabel = fileTooLarge
+    ? `${FREE_LIMITS.watermark.maxFileSizeMb} MB`
+    : undefined;
 
   const handleFileSelected = (selectedFiles) => {
     const selectedFile = selectedFiles[0];
     if (!selectedFile) return;
+
     if (selectedFile.type !== "application/pdf") {
       setError("Please upload a valid PDF file.");
       return;
     }
+
     setError(null);
     setFile(selectedFile);
+    setPreviewUrl(null);
   };
 
-  const clearFile = () => { setFile(null); setError(null); };
+  const clearFile = () => {
+    setFile(null);
+    setError(null);
+    setPreviewUrl(null);
+  };
 
   const handleProcess = async () => {
     if (!file || !watermarkText.trim()) return;
+
     try {
       setIsProcessing(true);
       setError(null);
+
       const watermarkedBlob = await addWatermark(file, watermarkText);
       const url = URL.createObjectURL(watermarkedBlob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = `QuickPDF_Watermarked_${Date.now()}.pdf`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
+
+      setPreviewUrl(url);
       await incrementUsage();
     } catch (err) {
       setError("An error occurred while adding the watermark.");
@@ -62,12 +78,17 @@ export function Watermark() {
         <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-zinc-900 border border-white/10 text-white mb-4">
           <Stamp className="w-8 h-8" />
         </div>
-        <h1 className="text-4xl font-extrabold text-white mb-4">Add Watermark</h1>
+
+        <h1 className="text-4xl font-extrabold text-white mb-4">
+          Add Watermark
+        </h1>
+
         <p className="text-lg text-zinc-400">
           Stamp text across your document securely in your browser.
           {!isPremium && (
             <span className="block text-sm text-zinc-600 mt-1">
-              Free tier: files up to {FREE_LIMITS.watermark.maxFileSizeMb} MB
+              Free tier: files up to{" "}
+              {FREE_LIMITS.watermark.maxFileSizeMb} MB
             </span>
           )}
         </p>
@@ -75,28 +96,49 @@ export function Watermark() {
 
       <div className="bg-[#0a0a0a] rounded-2xl border border-white/10 p-6 md:p-8 shadow-2xl">
         {error && (
-          <div className="mb-6 p-4 bg-red-500/10 text-red-400 rounded-lg text-sm border border-red-500/20">{error}</div>
+          <div className="mb-6 p-4 bg-red-500/10 text-red-400 rounded-lg text-sm border border-red-500/20">
+            {error}
+          </div>
         )}
 
         {!file ? (
-          <Dropzone onFilesSelected={handleFileSelected} multiple={false} disabled={isProcessing} text="Click to upload a PDF" />
+          <Dropzone
+            onFilesSelected={handleFileSelected}
+            multiple={false}
+            disabled={isProcessing}
+            text="Click to upload a PDF"
+          />
         ) : (
           <div className="space-y-8">
             <div className="flex items-center justify-between p-4 bg-zinc-900/50 border border-white/10 rounded-xl">
               <div className="flex flex-col overflow-hidden mr-4">
-                <span className="font-medium text-zinc-200 truncate">{file.name}</span>
+                <span className="font-medium text-zinc-200 truncate">
+                  {file.name}
+                </span>
+
                 <span className="text-sm text-zinc-500 mt-0.5">
                   {formatFileSize(file.size)}
-                  {fileTooLarge && <span className="text-amber-400 ml-2">(exceeds free limit)</span>}
+                  {fileTooLarge && (
+                    <span className="text-amber-400 ml-2">
+                      (exceeds free limit)
+                    </span>
+                  )}
                 </span>
               </div>
-              <button onClick={clearFile} className="p-2 text-zinc-500 hover:text-red-400 hover:bg-white/5 rounded-lg transition-colors">
+
+              <button
+                onClick={clearFile}
+                className="p-2 text-zinc-500 hover:text-red-400 hover:bg-white/5 rounded-lg transition-colors"
+              >
                 <X className="w-5 h-5" />
               </button>
             </div>
 
             <div className="space-y-2">
-              <label className="block text-sm font-medium text-zinc-400">Watermark Text</label>
+              <label className="block text-sm font-medium text-zinc-400">
+                Watermark Text
+              </label>
+
               <input
                 type="text"
                 value={watermarkText}
@@ -108,17 +150,57 @@ export function Watermark() {
 
             <div className="flex justify-end border-t border-white/10 pt-6">
               {isLocked ? (
-                <UpgradeButton reason={lockReason} limitLabel={lockLabel} isWalletConnected={isWalletConnected} isPremium={isPremium} className="w-full sm:w-auto" />
+                <UpgradeButton
+                  reason={lockReason}
+                  limitLabel={lockLabel}
+                  isWalletConnected={isWalletConnected}
+                  isPremium={isPremium}
+                  className="w-full sm:w-auto"
+                />
               ) : (
-                <Button onClick={handleProcess} disabled={isProcessing || !watermarkText.trim()} className="w-full sm:w-auto">
+                <Button
+                  onClick={handleProcess}
+                  disabled={isProcessing || !watermarkText.trim()}
+                  className="w-full sm:w-auto"
+                >
                   {isProcessing ? (
-                    <><Loader2 className="w-5 h-5 mr-2 animate-spin" />Processing...</>
+                    <>
+                      <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                      Processing...
+                    </>
                   ) : (
-                    <><Download className="w-5 h-5 mr-2" />Stamp & Download</>
+                    <>
+                      <Download className="w-5 h-5 mr-2" />
+                      Generate Preview
+                    </>
                   )}
                 </Button>
               )}
             </div>
+
+            {previewUrl && (
+              <div className="mt-8 space-y-4 border-t border-white/10 pt-6">
+                <h2 className="text-lg font-semibold text-white">
+                  Preview
+                </h2>
+
+                <iframe
+                  src={previewUrl}
+                  title="Watermarked PDF Preview"
+                  className="w-full h-[500px] rounded-xl border border-white/10 bg-white"
+                />
+
+                <a
+                  href={previewUrl}
+                  download={`QuickPDF_Watermarked_${Date.now()}.pdf`}
+                >
+                  <Button className="w-full sm:w-auto">
+                    <Download className="w-5 h-5 mr-2" />
+                    Download PDF
+                  </Button>
+                </a>
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
#What I changed

Implemented a **preview-before-download flow** for the watermark tool to improve the user experience.

 Changes included
* Replaced the direct auto-download flow with an in-app PDF preview
* Added a **Download PDF** button after preview generation
* Updated the main action button text to **Generate Preview**

## Testing done
* Tested with a sample PDF file
* Confirmed that the downloaded PDF matches the preview output



Refs #9 