### PR TITLE
fix: Lock navbar to top of page with fixed positioning

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -320,9 +320,9 @@ export function Navbar() {
   ];
 
   return (
-    <nav className="border-b border-white/10 bg-black/80 backdrop-blur-md sticky top-0 z-50">
+    <nav className="border-b border-white/10 bg-black/80 backdrop-blur-md fixed top-0 left-0 right-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between h-16 items-center gap-4">
+        <div className="flex justify-between h-16 items-center gap-4 relative">
 
           <Link to="/" className="flex items-center gap-2 group z-50 shrink-0">
             <div className="bg-white text-black p-1.5 rounded-md group-hover:scale-105 transition-transform">
@@ -332,7 +332,7 @@ export function Navbar() {
           </Link>
 
           {/* Desktop Navigation - 4 separate hover dropdowns */}
-          <div className="hidden lg:flex gap-6 flex-1 justify-center">
+          <div className="hidden lg:flex gap-6 absolute left-1/2 transform -translate-x-1/2">
             <EditDropdown />
             <ConvertDropdown />
             <OptimizeDropdown />

--- a/src/components/layout/PageContainer.jsx
+++ b/src/components/layout/PageContainer.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export function PageContainer({ children }) {
   return (
     // min-h-[calc(100vh-4rem)] ensures the container takes up the rest of the screen minus the 4rem (64px) Navbar height
-    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-[calc(100vh-4rem)]">
+    <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-[calc(100vh-4rem)] mt-16">
       {children}
     </main>
   );


### PR DESCRIPTION
## Description
Fixes UI bug where the navbar scrolls with the page instead of staying fixed at the top (Issue #21).

## Changes
- **Navbar Positioning**: Changed from `sticky` to `fixed` positioning to keep navbar always visible at top of screen
- **Full-Width Layout**: Added `left-0 right-0` to ensure navbar spans full viewport width
- **Centered Navigation**: Centered the navigation items (Edit, Convert, Optimize, Security) using absolute positioning with transform
- **Content Spacing**: Added `mt-16` top margin to PageContainer to prevent content from being hidden behind the fixed navbar

## Files Modified
- `src/components/layout/Navbar.jsx`: Changed positioning from sticky to fixed with proper centering
- `src/components/layout/PageContainer.jsx`: Added top margin offset for fixed navbar

https://github.com/user-attachments/assets/47d1b32f-869e-4bd0-a135-b8e4b801ce02

## Testing
- [x] Navbar stays fixed at top when scrolling
- [x] Navigation dropdowns work correctly
- [x] Content is not hidden behind navbar
- [x] Desktop layout displays centered navigation items
- [x] Mobile responsive design maintained

Fixes #21