### PR TITLE
fix-navbar-dropdown-bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3187,7 +3187,6 @@
         }
       }
     },
-
     "node_modules/@reown/appkit-pay": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
@@ -3545,7 +3544,6 @@
         }
       }
     },
-
     "node_modules/@reown/appkit-wallet": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
@@ -3855,7 +3853,6 @@
         }
       }
     },
-
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -6526,7 +6523,6 @@
         }
       }
     },
-
     "node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -107,20 +107,17 @@ function WalletMenu({ address, isPremium }) {
 // Edit Dropdown Component
 function EditDropdown() {
   const [isOpen, setIsOpen] = useState(false);
-  const [locked, setLocked] = useState(false);
   const location = useLocation();
   const shouldReset = location.pathname;
 
   useEffect(() => {
     queueMicrotask(() => {
       setIsOpen(false);
-      setLocked(false);
     });
   }, [shouldReset]);
   useEffect(() => {
     function handleCloseAll() {
       setIsOpen(false);
-      setLocked(false);
     }
 
     window.addEventListener("closeAllDropdowns", handleCloseAll);
@@ -140,16 +137,13 @@ function EditDropdown() {
   return (
     <div
       className="relative"
-      onMouseEnter={() => !locked && setIsOpen(true)}
-      onMouseLeave={() => {
-        if (!locked) setIsOpen(false);
-      }}
+      onMouseEnter={() => setIsOpen(true)}
+      onMouseLeave={() => setIsOpen(false)}
     >
       <button
         onClick={() => {
           window.dispatchEvent(new Event("closeAllDropdowns"));
           setIsOpen((prev) => !prev);
-          setLocked((prev) => !prev);
         }}
         className="flex items-center gap-1.5 text-sm font-medium text-zinc-400 hover:text-white transition-colors whitespace-nowrap group cursor-pointer">
         Edit
@@ -172,7 +166,6 @@ function EditDropdown() {
                   to={tool.path}
                   onClick={() => {
                     setIsOpen(false);
-                    setLocked(false);
                   }}
                   className={`block px-4 py-2 text-sm transition-all ${location.pathname === tool.path ? "text-white bg-white/10" : "text-zinc-400 hover:text-white hover:bg-white/5"}`}
                 >
@@ -190,20 +183,17 @@ function EditDropdown() {
 // Convert Dropdown Component
 function ConvertDropdown() {
   const [isOpen, setIsOpen] = useState(false);
-  const [locked, setLocked] = useState(false);
   const location = useLocation();
   const shouldReset = location.pathname;
 
   useEffect(() => {
     queueMicrotask(() => {
       setIsOpen(false);
-      setLocked(false);
     });
   }, [shouldReset]);
   useEffect(() => {
     function handleCloseAll() {
       setIsOpen(false);
-      setLocked(false);
     }
 
     window.addEventListener("closeAllDropdowns", handleCloseAll);
@@ -220,16 +210,13 @@ function ConvertDropdown() {
   return (
     <div
       className="relative"
-      onMouseEnter={() => !locked && setIsOpen(true)}
-      onMouseLeave={() => {
-        if (!locked) setIsOpen(false);
-      }}
+      onMouseEnter={() => setIsOpen(true)}
+      onMouseLeave={() => setIsOpen(false)}
     >
       <button
         onClick={() => {
           window.dispatchEvent(new Event("closeAllDropdowns"));
           setIsOpen((prev) => !prev);
-          setLocked((prev) => !prev);
         }}
         className="flex items-center gap-1.5 text-sm font-medium text-zinc-400 hover:text-white transition-colors whitespace-nowrap group cursor-pointer">
         Convert
@@ -252,7 +239,6 @@ function ConvertDropdown() {
                   to={tool.path}
                   onClick={() => {
                     setIsOpen(false);
-                    setLocked(false);
                   }}
                   className={`block px-4 py-2 text-sm transition-all ${location.pathname === tool.path ? "text-white bg-white/10" : "text-zinc-400 hover:text-white hover:bg-white/5"}`}
                 >
@@ -270,20 +256,17 @@ function ConvertDropdown() {
 // Optimize Dropdown Component
 function OptimizeDropdown() {
   const [isOpen, setIsOpen] = useState(false);
-  const [locked, setLocked] = useState(false);
   const location = useLocation();
   const shouldReset = location.pathname;
 
   useEffect(() => {
     queueMicrotask(() => {
       setIsOpen(false);
-      setLocked(false);
     });
   }, [shouldReset]);
   useEffect(() => {
     function handleCloseAll() {
       setIsOpen(false);
-      setLocked(false);
     }
 
     window.addEventListener("closeAllDropdowns", handleCloseAll);
@@ -301,16 +284,13 @@ function OptimizeDropdown() {
   return (
     <div
       className="relative"
-      onMouseEnter={() => !locked && setIsOpen(true)}
-      onMouseLeave={() => {
-        if (!locked) setIsOpen(false);
-      }}
+      onMouseEnter={() => setIsOpen(true)}
+      onMouseLeave={() => setIsOpen(false)}
     >
       <button
         onClick={() => {
           window.dispatchEvent(new Event("closeAllDropdowns"));
           setIsOpen((prev) => !prev);
-          setLocked((prev) => !prev);
         }}
         className="flex items-center gap-1.5 text-sm font-medium text-zinc-400 hover:text-white transition-colors whitespace-nowrap group cursor-pointer">
         Optimize
@@ -333,7 +313,6 @@ function OptimizeDropdown() {
                   to={tool.path}
                   onClick={() => {
                     setIsOpen(false);
-                    setLocked(false);
                   }}
                   className={`block px-4 py-2 text-sm transition-all ${location.pathname === tool.path ? "text-white bg-white/10" : "text-zinc-400 hover:text-white hover:bg-white/5"}`}
                 >
@@ -351,20 +330,17 @@ function OptimizeDropdown() {
 // Security Dropdown Component
 function SecurityDropdown() {
   const [isOpen, setIsOpen] = useState(false);
-  const [locked, setLocked] = useState(false);
   const location = useLocation();
   const shouldReset = location.pathname;
 
   useEffect(() => {
     queueMicrotask(() => {
       setIsOpen(false);
-      setLocked(false);
     });
   }, [shouldReset]);
   useEffect(() => {
     function handleCloseAll() {
       setIsOpen(false);
-      setLocked(false);
     }
 
     window.addEventListener("closeAllDropdowns", handleCloseAll);
@@ -380,16 +356,13 @@ function SecurityDropdown() {
   return (
     <div
       className="relative"
-      onMouseEnter={() => !locked && setIsOpen(true)}
-      onMouseLeave={() => {
-        if (!locked) setIsOpen(false);
-      }}
+      onMouseEnter={() => setIsOpen(true)}
+      onMouseLeave={() => setIsOpen(false)}
     >
       <button
         onClick={() => {
           window.dispatchEvent(new Event("closeAllDropdowns"));
           setIsOpen((prev) => !prev);
-          setLocked((prev) => !prev);
         }}
         className="flex items-center gap-1.5 text-sm font-medium text-zinc-400 hover:text-white transition-colors whitespace-nowrap group cursor-pointer">
         Security
@@ -412,7 +385,6 @@ function SecurityDropdown() {
                   to={tool.path}
                   onClick={() => {
                     setIsOpen(false);
-                    setLocked(false);
                   }}
                   className={`block px-4 py-2 text-sm transition-all ${location.pathname === tool.path ? "text-white bg-white/10" : "text-zinc-400 hover:text-white hover:bg-white/5"
                     }`}


### PR DESCRIPTION
Issue : #79

Fix: Resolve stuck dropdown menu issue on click in Navbar

Description: This PR fixes a UI bug in the navigation bar where dropdown menus (Edit, Convert, Optimize, Security) would get "stuck" in an open state after being clicked, even if the user moved their cursor away. The intended behavior was for the dropdowns to behave consistently with the hover state.


Changes Made:

Removed the locked state variable and its associated logic from all 4 dropdown components (EditDropdown, ConvertDropdown, OptimizeDropdown, and SecurityDropdown) in src/components/layout/Navbar.jsx.
Simplified the onMouseEnter and onMouseLeave event handlers to exclusively control the isOpen state, ensuring the menus fold naturally when the cursor moves away, regardless of click events.
